### PR TITLE
add multi context check

### DIFF
--- a/core/components/quickapi/elements/plugins/QuickApiRoute.php
+++ b/core/components/quickapi/elements/plugins/QuickApiRoute.php
@@ -16,11 +16,15 @@ if ($event == 'OnMODXInit') {
     
     // Get the path root property
     $pathRoot = $modx->getOption('quickapi.path_root', null, 'api/');
-    
+        
+    // Multi Context Mode    
+    preg_match('/^((en|de)\/)?/i', $identifier, $baseUrl);
+    $aliasPrefix = $baseUrl[0];
+
     // If the identifier starts with the path root
-    if (substr($identifier, 0, 4) === $pathRoot) {
+    if (substr($identifier, 0, strlen($aliasPrefix . $pathRoot)) == $aliasPrefix . $pathRoot) {
         // Override the request alias
-        $_REQUEST[$rAlias] = "quickapi-process";
-        $_REQUEST['_quickapi'] = str_replace('api/', '', $identifier);
+        $_REQUEST[$rAlias] = $aliasPrefix . 'quickapi-process';
+        $_REQUEST['_quickapi'] = str_replace($aliasPrefix . 'api/', '', $identifier);
     }
 }


### PR DESCRIPTION
Hej @jaredfhealy,
i came across another thing to check. I have a multi context installation and need different resources in each context with alias "quickapi-process" (= endpoints). The current check only matches if no cultureKey is set inside the URL like this:

- https://domain.com/api/endpoint/ > context: web > resource alias: quickapi-process (1)
- https://domain.com/en/api/endpoint/ > context: web > 404

I added a regex to filter the cultureKeys from the URL and add them to the check as a prefix. Maybe this regex could be set as a system setting? With the change this works now:

- https://domain.com/api/endpoint/ > context: web > resource alias: quickapi-process (1)
- https://domain.com/en/api/endpoint/ > context: en > resource alias: quickapi-process (2)

If you have another solution to solve this, lets talk 😸 